### PR TITLE
Generate JS from Proto on Mac

### DIFF
--- a/generated/md/build.sh
+++ b/generated/md/build.sh
@@ -34,7 +34,7 @@ sed -i '' '1i\
 ---\
 title: Trade API\
 pageTitle: Cube - Trade API\
-description: Trade crypto at microsecond speeds, so your market maker code never miss a tick.\
+description: Trade crypto at microsecond speeds so your market making code never misses a tick.\
 ---' ./src/trade.md
 
 ONCE=(

--- a/generated/md/src/trade.md
+++ b/generated/md/src/trade.md
@@ -1,7 +1,7 @@
 ---
 title: Trade API
 pageTitle: Cube - Trade API
-description: Trade crypto at microsecond speeds, so your market maker code never miss a tick.
+description: Trade crypto at microsecond speeds so your market making code never misses a tick.
 ---
 
 ## trade.proto


### PR DESCRIPTION
The `build.sh` script was generating invalid code on my machine.

Replaced "diff" with "git diff" for consistency across platforms.

Tested that this generates the same files as those already in the repo.