### PR TITLE
updating for GitBook

### DIFF
--- a/generated/js/src/market_data.ts
+++ b/generated/js/src/market_data.ts
@@ -13,13 +13,13 @@ export const protobufPackage = "market_data";
  * price level through the Market by Price (MBP) and order-by-order through the
  * Market by Order (MBO). In addition, clients can subscribe to the trade stream
  * and price candlesticks. Clients should submit a [`Config`](#config) and then
- * process [`MdMessage`'s](#md-message).
+ * process [`MdMessage`](#mdmessage)'s.
  *
  * ### Aggregate Book Tops Data
  *
  * The market data service exposes a websocket endpoint for aggregated
  * tops-of-book for all markets at `/tops`. Client should process
- * [`AggMessage`](#agg-message).
+ * [`AggMessage`](#aggmessage).
  *
  * ### Heartbeats
  *
@@ -67,7 +67,7 @@ export enum RateUpdateSide {
 
 /**
  * Every exchange message from `/book/:market_id` will be wrapped as an
- * [`MdMessages`](#md-messages) which contains multiple `MdMessage`'s.
+ * [`MdMessages`](#mdmessages) which contains multiple `MdMessage`'s.
  */
 export interface MdMessage {
   /** Server heartbeat reply */
@@ -182,7 +182,7 @@ export interface MarketByOrder {
 export interface MarketByOrder_Order {
   price: bigint;
   quantity: bigint;
-  /** [Exchange order ID](/docs/api_reference/trade#exchange-order-id) */
+  /** [Exchange order ID](./websocket-trade-api.md#exchange-order-id) */
   exchangeOrderId: bigint;
   side: Side;
   /**
@@ -233,11 +233,11 @@ export enum MarketByOrderDiff_DiffOp {
 export interface MarketByOrderDiff_Diff {
   price: bigint;
   quantity: bigint;
-  /** [Exchange order ID](/docs/api_reference/trade#exchange-order-id) */
+  /** [Exchange order ID](./websocket-trade-api.md#exchange-order-id) */
   exchangeOrderId: bigint;
   side: Side;
   op: MarketByOrderDiff_DiffOp;
-  /** See [`MarketByOrder.Order`](#market-by-order-order) */
+  /** See [`MarketByOrder.Order`](#marketbyorder.order) */
   priority: bigint;
 }
 
@@ -261,19 +261,19 @@ export interface Trades_Trade {
   /** The side of the aggressing order. */
   aggressingSide: Side;
   /**
-   * The [Exchange order ID](/docs/api_reference/trade#exchange-order-id) of
+   * The [Exchange order ID](./websocket-trade-api.md#exchange-order-id) of
    * the resting order.
    */
   restingExchangeOrderId: bigint;
   fillQuantity: bigint;
   /**
-   * The [transact time](/docs/api_reference/trade#transact-time) assigned by
+   * The [transact time](./websocket-trade-api.md#transact-time) assigned by
    * the matching engine for this trade. All trades that occur from the same
    * event will be assigned the same transact time.
    */
   transactTime: bigint;
   /**
-   * The [Exchange order ID](/docs/api_reference/trade#exchange-order-id) of
+   * The [Exchange order ID](./websocket-trade-api.md#exchange-order-id) of
    * the aggressing order.
    */
   aggressingExchangeOrderId: bigint;
@@ -350,7 +350,7 @@ export interface AggMessage {
 export interface TopOfBook {
   marketId: bigint;
   /**
-   * The [transact time](/docs/api_reference/trade#transact-time) of the latest
+   * The [transact time](./websocket-trade-api.md#transact-time) of the latest
    * book update on this market.
    */
   transactTime: bigint;

--- a/generated/js/src/trade.ts
+++ b/generated/js/src/trade.ts
@@ -12,8 +12,8 @@ export const protobufPackage = "trade";
  * Once connected, clients should submit a [`Credentials`](#credentials)
  * message, listen for [`Bootstrap`](#bootstrap) messages for resting orders
  * and positions, and then can begin submitting
- * [`OrderRequest`](#order-request) and processing
- * [`OrderResponse`](#order-response).
+ * [`OrderRequest`](#orderrequest) and processing
+ * [`OrderResponse`](#orderresponse).
  *
  * ### Heartbeats
  *
@@ -78,7 +78,7 @@ export const protobufPackage = "trade";
  *
  * If you need exact granularity at time of trade, you can replicate the fee calculation performed by the exchange.
  * To avoid rounding errors, this entire process is performed in integer math using the exponent as a devisor.
- * In the example above, the full fee amount in indivisible [RawUnits](#raw-units) would be calculated as:
+ * In the example above, the full fee amount in indivisible [RawUnits](#rawunits) would be calculated as:
  * ```text
  * 5 * 100_000_000 * 11 / 10_000 = 550_000 RawUnits
  *

--- a/generated/md/build.sh
+++ b/generated/md/build.sh
@@ -31,11 +31,7 @@ protoc \
   --proto_path="$SCHEMAS" "$SCHEMAS"/trade.proto
 
 sed -i '' '1i\
----\
-title: Trade API\
-pageTitle: Cube - Trade API\
-description: Trade crypto at microsecond speeds so your market making code never misses a tick.\
----' ./src/trade.md
+# WebSocket: Trade API' ./src/trade.md
 
 ONCE=(
   # order request
@@ -85,11 +81,7 @@ protoc \
   --proto_path="$SCHEMAS" "$SCHEMAS"/market_data.proto
 
 sed -i '' '1i\
----\
-title: Market Data API\
-pageTitle: Cube - Market Data API\
-description: Trade crypto at microsecond speeds, so your market maker code never miss a tick.\
----' ./src/market_data.md
+# WebSocket: Market Data API' ./src/market_data.md
 
 ONCE=(
   # md message

--- a/generated/md/src/market_data.md
+++ b/generated/md/src/market_data.md
@@ -1,8 +1,4 @@
----
-title: Market Data API
-pageTitle: Cube - Market Data API
-description: Trade crypto at microsecond speeds, so your market maker code never miss a tick.
----
+# WebSocket: Market Data API
 
 ## market_data.proto
 This schema defines the Protobuf messages used for communication with the
@@ -15,13 +11,13 @@ a given market at `/book/:market_id`. The order book can be consumed by both
 price level through the Market by Price (MBP) and order-by-order through the
 Market by Order (MBO). In addition, clients can subscribe to the trade stream
 and price candlesticks. Clients should submit a [`Config`](#config) and then
-process [`MdMessage`'s](#md-message).
+process [`MdMessage`](#mdmessage)'s.
 
 ### Aggregate Book Tops Data
 
 The market data service exposes a websocket endpoint for aggregated
 tops-of-book for all markets at `/tops`. Client should process
-[`AggMessage`](#agg-message).
+[`AggMessage`](#aggmessage).
 
 ### Heartbeats
 
@@ -32,7 +28,7 @@ interval is missed, the market data service will disconnect the websocket.
 
 ## MdMessage
 Every exchange message from `/book/:market_id` will be wrapped as an
-[`MdMessages`](#md-messages) which contains multiple `MdMessage`'s.
+[`MdMessages`](#mdmessages) which contains multiple `MdMessage`'s.
 
 
 | Field | Type | Label | Description |
@@ -40,10 +36,10 @@ Every exchange message from `/book/:market_id` will be wrapped as an
 | heartbeat | [Heartbeat](#heartbeat) |  | Server heartbeat reply |
 | summary | [Summary](#summary) |  | 24h summary |
 | trades | [Trades](#trades) |  | Recent trades |
-| mbo_snapshot | [MarketByOrder](#market-by-order) |  | Market by order snapshot |
-| mbo_diff | [MarketByOrderDiff](#market-by-order-diff) |  | Market by order diff |
-| mbp_snapshot | [MarketByPrice](#market-by-price) |  | Market by price snapshot |
-| mbp_diff | [MarketByPriceDiff](#market-by-price-diff) |  | Market by price diff |
+| mbo_snapshot | [MarketByOrder](#marketbyorder) |  | Market by order snapshot |
+| mbo_diff | [MarketByOrderDiff](#marketbyorderdiff) |  | Market by order diff |
+| mbp_snapshot | [MarketByPrice](#marketbyprice) |  | Market by price snapshot |
+| mbp_diff | [MarketByPriceDiff](#marketbypricediff) |  | Market by price diff |
 | kline | [Kline](#kline) |  | Candlestick |
 
 
@@ -62,7 +58,7 @@ levels, but no ordering is guaranteed.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| levels | [MarketByPrice.Level](#market-by-price-level) | repeated |  |
+| levels | [MarketByPrice.Level](#marketbyprice.level) | repeated |  |
 | chunk | [uint32](#uint32) |  |  |
 | num_chunks | [uint32](#uint32) |  |  |
 
@@ -97,7 +93,7 @@ reconciliation.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| diffs | [MarketByPriceDiff.Diff](#market-by-price-diff-diff) | repeated |  |
+| diffs | [MarketByPriceDiff.Diff](#marketbypricediff.diff) | repeated |  |
 | total_bid_levels | [uint32](#uint32) |  | Total number of bid levels after this diff is applied. |
 | total_ask_levels | [uint32](#uint32) |  | Total number of ask levels after this diff is applied. |
 
@@ -116,7 +112,7 @@ A price level diff overwrites the existing price level.
 | price | [uint64](#uint64) |  |  |
 | quantity | [uint64](#uint64) |  |  |
 | side | [Side](#side) |  |  |
-| op | [MarketByPriceDiff.DiffOp](#market-by-price-diff-diff-op) |  |  |
+| op | [MarketByPriceDiff.DiffOp](#marketbypricediff.diffop) |  |  |
 
 
 
@@ -134,7 +130,7 @@ matched when that level is aggressed.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| orders | [MarketByOrder.Order](#market-by-order-order) | repeated |  |
+| orders | [MarketByOrder.Order](#marketbyorder.order) | repeated |  |
 | chunk | [uint32](#uint32) |  |  |
 | num_chunks | [uint32](#uint32) |  |  |
 
@@ -152,7 +148,7 @@ A resting order.
 | ----- | ---- | ----- | ----------- |
 | price | [uint64](#uint64) |  |  |
 | quantity | [uint64](#uint64) |  |  |
-| exchange_order_id | [uint64](#uint64) |  | [Exchange order ID](/docs/api_reference/trade#exchange-order-id) |
+| exchange_order_id | [uint64](#uint64) |  | [Exchange order ID](./websocket-trade-api.md#exchange-order-id) |
 | side | [Side](#side) |  |  |
 | priority | [uint64](#uint64) |  | Order priority for execution. Valid within a price level and side. That is, orders must first be sorted by side and price (in descending order for bids and ascending for asks), and then the OrderPriority within the level. A lower value is a higher priority. |
 
@@ -174,7 +170,7 @@ exchange order ID will not change.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| diffs | [MarketByOrderDiff.Diff](#market-by-order-diff-diff) | repeated |  |
+| diffs | [MarketByOrderDiff.Diff](#marketbyorderdiff.diff) | repeated |  |
 | total_bid_levels | [uint32](#uint32) |  | Total number of bid levels after this diff is applied. |
 | total_ask_levels | [uint32](#uint32) |  | Total number of ask levels after this diff is applied. |
 | total_bid_orders | [uint32](#uint32) |  | Total number of bid orders after this diff is applied. |
@@ -195,10 +191,10 @@ An order diff creates, updates, or deletes a resting order based on the
 | ----- | ---- | ----- | ----------- |
 | price | [uint64](#uint64) |  |  |
 | quantity | [uint64](#uint64) |  |  |
-| exchange_order_id | [uint64](#uint64) |  | [Exchange order ID](/docs/api_reference/trade#exchange-order-id) |
+| exchange_order_id | [uint64](#uint64) |  | [Exchange order ID](./websocket-trade-api.md#exchange-order-id) |
 | side | [Side](#side) |  |  |
-| op | [MarketByOrderDiff.DiffOp](#market-by-order-diff-diff-op) |  |  |
-| priority | [uint64](#uint64) |  | See [`MarketByOrder.Order`](#market-by-order-order) |
+| op | [MarketByOrderDiff.DiffOp](#marketbyorderdiff.diffop) |  |  |
+| priority | [uint64](#uint64) |  | See [`MarketByOrder.Order`](#marketbyorder.order) |
 
 
 
@@ -214,7 +210,7 @@ orders and levels, respectively.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| trades | [Trades.Trade](#trades-trade) | repeated |  |
+| trades | [Trades.Trade](#trades.trade) | repeated |  |
 
 
 
@@ -231,10 +227,10 @@ orders and levels, respectively.
 | tradeId | [uint64](#uint64) |  | The ID assigned to this trade. All trades that occur from the same event will be assigned the same ID, and are considered to be an atomic batch. |
 | price | [uint64](#uint64) |  | The price that this trade occurred at. |
 | aggressing_side | [Side](#side) |  | The side of the aggressing order. |
-| resting_exchange_order_id | [uint64](#uint64) |  | The [Exchange order ID](/docs/api_reference/trade#exchange-order-id) of the resting order. |
+| resting_exchange_order_id | [uint64](#uint64) |  | The [Exchange order ID](./websocket-trade-api.md#exchange-order-id) of the resting order. |
 | fill_quantity | [uint64](#uint64) |  |  |
-| transact_time | [uint64](#uint64) |  | The [transact time](/docs/api_reference/trade#transact-time) assigned by the matching engine for this trade. All trades that occur from the same event will be assigned the same transact time. |
-| aggressing_exchange_order_id | [uint64](#uint64) |  | The [Exchange order ID](/docs/api_reference/trade#exchange-order-id) of the aggressing order. |
+| transact_time | [uint64](#uint64) |  | The [transact time](./websocket-trade-api.md#transact-time) assigned by the matching engine for this trade. All trades that occur from the same event will be assigned the same transact time. |
+| aggressing_exchange_order_id | [uint64](#uint64) |  | The [Exchange order ID](./websocket-trade-api.md#exchange-order-id) of the aggressing order. |
 
 
 
@@ -269,7 +265,7 @@ Candlestick bar.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| interval | [KlineInterval](#kline-interval) |  |  |
+| interval | [KlineInterval](#klineinterval) |  |  |
 | start_time | [uint64](#uint64) |  | The unix nanosecond timestamp that this kline covers. |
 | open | [uint64](#uint64) |  | Kline open price. |
 | close | [uint64](#uint64) |  | Kline close price. |
@@ -306,7 +302,7 @@ value, comes from the market data service.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| messages | [MdMessage](#md-message) | repeated |  |
+| messages | [MdMessage](#mdmessage) | repeated |  |
 
 
 
@@ -321,8 +317,8 @@ Every exchange message from `/tops` will be wrapped as an `AggMessage`.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | heartbeat | [Heartbeat](#heartbeat) |  | Server heartbeat reply |
-| top_of_books | [TopOfBooks](#top-of-books) |  | Top of books |
-| rate_updates | [RateUpdates](#rate-updates) |  | Rates for all assets |
+| top_of_books | [TopOfBooks](#topofbooks) |  | Top of books |
+| rate_updates | [RateUpdates](#rateupdates) |  | Rates for all assets |
 
 
 
@@ -337,7 +333,7 @@ Top of book
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | market_id | [uint64](#uint64) |  |  |
-| transact_time | [uint64](#uint64) |  | The [transact time](/docs/api_reference/trade#transact-time) of the latest book update on this market. |
+| transact_time | [uint64](#uint64) |  | The [transact time](./websocket-trade-api.md#transact-time) of the latest book update on this market. |
 | bid_price | [uint64](#uint64) |  | The best bid price. |
 | bid_quantity | [uint64](#uint64) |  | The total bid quantity at the best bid price. |
 | ask_price | [uint64](#uint64) |  | The best ask price. |
@@ -358,7 +354,7 @@ message.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| tops | [TopOfBook](#top-of-book) | repeated |  |
+| tops | [TopOfBook](#topofbook) | repeated |  |
 
 
 
@@ -378,7 +374,7 @@ EUR, updateSide = QUOTE` of `r2`, the BTC-EUR price estimate is `r1 * r2`.
 | asset_id | [uint64](#uint64) |  |  |
 | timestamp | [uint64](#uint64) |  | The nanosecond timestamp of the update. |
 | rate | [uint64](#uint64) |  | The asset rate at the given timestamp. |
-| side | [RateUpdateSide](#rate-update-side) |  |  |
+| side | [RateUpdateSide](#rateupdateside) |  |  |
 
 
 
@@ -393,7 +389,7 @@ rate-updates message.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| updates | [RateUpdate](#rate-update) | repeated |  |
+| updates | [RateUpdate](#rateupdate) | repeated |  |
 
 
 
@@ -429,7 +425,7 @@ and `mbo` can be set.
 | mbo | [bool](#bool) |  | Enable MBO feeds |
 | trades | [bool](#bool) |  | Enable recent trades |
 | summary | [bool](#bool) |  | Enable 24h summary |
-| klines | [KlineInterval](#kline-interval) | repeated | Enable price klines |
+| klines | [KlineInterval](#klineinterval) | repeated | Enable price klines |
 
 
 

--- a/generated/md/src/trade.md
+++ b/generated/md/src/trade.md
@@ -1,8 +1,4 @@
----
-title: Trade API
-pageTitle: Cube - Trade API
-description: Trade crypto at microsecond speeds so your market making code never misses a tick.
----
+# WebSocket: Trade API
 
 ## trade.proto
 This schema defines the Protobuf messages used for communication with the
@@ -14,8 +10,8 @@ The order service exposes a websocket endpoint for clients to connect to.
 Once connected, clients should submit a [`Credentials`](#credentials)
 message, listen for [`Bootstrap`](#bootstrap) messages for resting orders
 and positions, and then can begin submitting
-[`OrderRequest`](#order-request) and processing
-[`OrderResponse`](#order-response).
+[`OrderRequest`](#orderrequest) and processing
+[`OrderResponse`](#orderresponse).
 
 ### Heartbeats
 
@@ -80,7 +76,7 @@ For example, consider the case of a trade where:
 
 If you need exact granularity at time of trade, you can replicate the fee calculation performed by the exchange.
 To avoid rounding errors, this entire process is performed in integer math using the exponent as a devisor.
-In the example above, the full fee amount in indivisible [RawUnits](#raw-units) would be calculated as:
+In the example above, the full fee amount in indivisible [RawUnits](#rawunits) would be calculated as:
 ```text
 5 * 100_000_000 * 11 / 10_000 = 550_000 RawUnits
 
@@ -201,11 +197,11 @@ OrderRequest.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| new | [NewOrder](#new-order) |  |  |
-| cancel | [CancelOrder](#cancel-order) |  |  |
-| modify | [ModifyOrder](#modify-order) |  |  |
+| new | [NewOrder](#neworder) |  |  |
+| cancel | [CancelOrder](#cancelorder) |  |  |
+| modify | [ModifyOrder](#modifyorder) |  |  |
 | heartbeat | [Heartbeat](#heartbeat) |  |  |
-| mc | [MassCancel](#mass-cancel) |  |  |
+| mc | [MassCancel](#masscancel) |  |  |
 
 
 
@@ -225,11 +221,11 @@ Place a new order.
 | price | [uint64](#uint64) | optional |  |
 | quantity | [uint64](#uint64) |  |  |
 | side | [Side](#side) |  |  |
-| time_in_force | [TimeInForce](#time-in-force) |  |  |
-| order_type | [OrderType](#order-type) |  |  |
+| time_in_force | [TimeInForce](#timeinforce) |  |  |
+| order_type | [OrderType](#ordertype) |  |  |
 | subaccount_id | [uint64](#uint64) |  | The subaccount to place this order on. This subaccount must be writable by the API key specified in the Credentials message. |
-| self_trade_prevention | [SelfTradePrevention](#self-trade-prevention) | optional |  |
-| post_only | [PostOnly](#post-only) |  |  |
+| self_trade_prevention | [SelfTradePrevention](#selftradeprevention) | optional |  |
+| post_only | [PostOnly](#postonly) |  |  |
 | cancel_on_disconnect | [bool](#bool) |  | If true, this order will be automatically cancelled after the closure of the network connection between Cube's servers and the client that placed the order.
 
 If the client initiates the disconnect or network instability drops the connection, the order will be cancelled when Cube's servers recognize the disconnection.
@@ -297,8 +293,8 @@ remaining_quantity + cumulative_quantity`.
 | new_price | [uint64](#uint64) |  |  |
 | new_quantity | [uint64](#uint64) |  |  |
 | subaccount_id | [uint64](#uint64) |  | The subaccount that the NewOrder was placed on. |
-| self_trade_prevention | [SelfTradePrevention](#self-trade-prevention) | optional |  |
-| post_only | [PostOnly](#post-only) |  |  |
+| self_trade_prevention | [SelfTradePrevention](#selftradeprevention) | optional |  |
+| post_only | [PostOnly](#postonly) |  |  |
 
 
 
@@ -352,16 +348,16 @@ OrderResponse.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| new_ack | [NewOrderAck](#new-order-ack) |  |  |
-| cancel_ack | [CancelOrderAck](#cancel-order-ack) |  |  |
-| modify_ack | [ModifyOrderAck](#modify-order-ack) |  |  |
-| new_reject | [NewOrderReject](#new-order-reject) |  |  |
-| cancel_reject | [CancelOrderReject](#cancel-order-reject) |  |  |
-| modify_reject | [ModifyOrderReject](#modify-order-reject) |  |  |
+| new_ack | [NewOrderAck](#neworderack) |  |  |
+| cancel_ack | [CancelOrderAck](#cancelorderack) |  |  |
+| modify_ack | [ModifyOrderAck](#modifyorderack) |  |  |
+| new_reject | [NewOrderReject](#neworderreject) |  |  |
+| cancel_reject | [CancelOrderReject](#cancelorderreject) |  |  |
+| modify_reject | [ModifyOrderReject](#modifyorderreject) |  |  |
 | fill | [Fill](#fill) |  |  |
 | heartbeat | [Heartbeat](#heartbeat) |  |  |
-| position | [AssetPosition](#asset-position) |  |  |
-| mass_cancel_ack | [MassCancelAck](#mass-cancel-ack) |  |  |
+| position | [AssetPosition](#assetposition) |  |  |
+| mass_cancel_ack | [MassCancelAck](#masscancelack) |  |  |
 
 
 
@@ -384,8 +380,8 @@ any fills for this order.
 | price | [uint64](#uint64) | optional | If the order ultimately rests, the `price` field will include the resting price. |
 | quantity | [uint64](#uint64) |  | The quantity submitted in the new-order request. |
 | side | [Side](#side) |  |  |
-| time_in_force | [TimeInForce](#time-in-force) |  |  |
-| order_type | [OrderType](#order-type) |  |  |
+| time_in_force | [TimeInForce](#timeinforce) |  |  |
+| order_type | [OrderType](#ordertype) |  |  |
 | transact_time | [uint64](#uint64) |  | [Transact time](#transact-time) |
 | subaccount_id | [uint64](#uint64) |  |  |
 | cancel_on_disconnect | [bool](#bool) |  |  |
@@ -408,7 +404,7 @@ canceled as the result of a different user-initiated reason.
 | request_id | [uint64](#uint64) |  | If the Reason is `DISCONNECT`, `IOC`, `STP_RESTING`, or `STP_AGGRESSING`, this request ID will be `u64::MAX`. Otherwise, it will be the request ID of the initiated cancel action. For a mass cancel, each cancel order ack will have the MassCancel's request_id. |
 | transact_time | [uint64](#uint64) |  | [Transact time](#transact-time) |
 | subaccount_id | [uint64](#uint64) |  |  |
-| reason | [CancelOrderAck.Reason](#cancel-order-ack-reason) |  |  |
+| reason | [CancelOrderAck.Reason](#cancelorderack.reason) |  |  |
 | market_id | [uint64](#uint64) |  |  |
 | exchange_order_id | [uint64](#uint64) |  | [Exchange order ID](#exchange-order-id) |
 
@@ -456,7 +452,7 @@ CancelOrderAck's will be sent for each order that was affected.
 | subaccount_id | [uint64](#uint64) |  |  |
 | request_id | [uint64](#uint64) |  | The request ID specified in the mass-cancel request. |
 | transact_time | [uint64](#uint64) |  | [Transact time](#transact-time) |
-| reason | [MassCancelAck.Reason](#mass-cancel-ack-reason) | optional |  |
+| reason | [MassCancelAck.Reason](#masscancelack.reason) | optional |  |
 | total_affected_orders | [uint32](#uint32) |  | The total number of orders that were canceled. |
 
 
@@ -476,13 +472,13 @@ New-order-reject indicates that a new-order request was not applied.
 | request_id | [uint64](#uint64) |  | The request ID specified in the new-order request. |
 | transact_time | [uint64](#uint64) |  | [Transact time](#transact-time) |
 | subaccount_id | [uint64](#uint64) |  |  |
-| reason | [NewOrderReject.Reason](#new-order-reject-reason) |  |  |
+| reason | [NewOrderReject.Reason](#neworderreject.reason) |  |  |
 | market_id | [uint64](#uint64) |  |  |
 | price | [uint64](#uint64) | optional |  |
 | quantity | [uint64](#uint64) |  |  |
 | side | [Side](#side) |  |  |
-| time_in_force | [TimeInForce](#time-in-force) |  |  |
-| order_type | [OrderType](#order-type) |  |  |
+| time_in_force | [TimeInForce](#timeinforce) |  |  |
+| order_type | [OrderType](#ordertype) |  |  |
 
 
 
@@ -501,7 +497,7 @@ Cancel-order-reject indicates that a cancel-order request was not applied.
 | request_id | [uint64](#uint64) |  | The request ID specified in the cancel-order request. |
 | transact_time | [uint64](#uint64) |  | [Transact time](#transact-time) |
 | subaccount_id | [uint64](#uint64) |  |  |
-| reason | [CancelOrderReject.Reason](#cancel-order-reject-reason) |  |  |
+| reason | [CancelOrderReject.Reason](#cancelorderreject.reason) |  |  |
 | market_id | [uint64](#uint64) |  |  |
 
 
@@ -521,7 +517,7 @@ Modify-order-reject indicates that a modify-order request was not applied.
 | request_id | [uint64](#uint64) |  | The request ID specified in the modify-order request. |
 | transact_time | [uint64](#uint64) |  | [Transact time](#transact-time) |
 | subaccount_id | [uint64](#uint64) |  |  |
-| reason | [ModifyOrderReject.Reason](#modify-order-reject-reason) |  |  |
+| reason | [ModifyOrderReject.Reason](#modifyorderreject.reason) |  |  |
 | market_id | [uint64](#uint64) |  |  |
 
 
@@ -548,7 +544,7 @@ A fill for an order.
 | cumulative_quantity | [uint64](#uint64) |  | The cumulative filled quantity for this order after the fill is applied. |
 | side | [Side](#side) |  |  |
 | aggressor_indicator | [bool](#bool) |  |  |
-| fee_ratio | [FixedPointDecimal](#fixed-point-decimal) |  | Indicates the fee charged on this trade. See [Fees](#fees) for details. |
+| fee_ratio | [FixedPointDecimal](#fixedpointdecimal) |  | Indicates the fee charged on this trade. See [Fees](#fees) for details. |
 | trade_id | [uint64](#uint64) |  | The unique trade ID associated with a match event. Each order participanting in the match event will receive this trade ID |
 
 
@@ -567,8 +563,8 @@ can also be tracked by applying other OrderResponse messages individually.
 | ----- | ---- | ----- | ----------- |
 | subaccount_id | [uint64](#uint64) |  |  |
 | asset_id | [uint64](#uint64) |  |  |
-| total | [RawUnits](#raw-units) |  |  |
-| available | [RawUnits](#raw-units) |  | The available amount after open orders are subtracted. |
+| total | [RawUnits](#rawunits) |  |  |
+| available | [RawUnits](#rawunits) |  | The available amount after open orders are subtracted. |
 
 
 
@@ -610,8 +606,8 @@ and these should be concatenated.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | done | [Done](#done) |  |  |
-| resting | [RestingOrders](#resting-orders) |  |  |
-| position | [AssetPositions](#asset-positions) |  |  |
+| resting | [RestingOrders](#restingorders) |  |  |
+| position | [AssetPositions](#assetpositions) |  |  |
 
 
 
@@ -625,7 +621,7 @@ A chunk of resting orders. Sent on bootstrap.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| orders | [RestingOrder](#resting-order) | repeated |  |
+| orders | [RestingOrder](#restingorder) | repeated |  |
 
 
 
@@ -639,7 +635,7 @@ A chunk of asset positions. Sent on bootstrap.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| positions | [AssetPosition](#asset-position) | repeated |  |
+| positions | [AssetPosition](#assetposition) | repeated |  |
 
 
 
@@ -674,8 +670,8 @@ A resting order. Sent on bootstrap in `RestingOrders`.
 | price | [uint64](#uint64) |  |  |
 | order_quantity | [uint64](#uint64) |  | The quantity submitted in the latest quantity-modifying request. If the order has not been modified, then it is the quantity on the new-order-ack. If it has been modified, then it is the quantity of the latest modify-order-ack. |
 | side | [Side](#side) |  |  |
-| time_in_force | [TimeInForce](#time-in-force) |  |  |
-| order_type | [OrderType](#order-type) |  |  |
+| time_in_force | [TimeInForce](#timeinforce) |  |  |
+| order_type | [OrderType](#ordertype) |  |  |
 | remaining_quantity | [uint64](#uint64) |  | The current remaining quantity on the book. |
 | rest_time | [uint64](#uint64) |  | [Transact time](#transact-time) of the NewOrderAck |
 | subaccount_id | [uint64](#uint64) |  |  |

--- a/generated/rust/src/market_data.rs
+++ b/generated/rust/src/market_data.rs
@@ -1,5 +1,5 @@
 /// Every exchange message from `/book/:market_id` will be wrapped as an
-/// \[`MdMessages`\](#md-messages) which contains multiple `MdMessage`'s.
+/// \[`MdMessages`\](#mdmessages) which contains multiple `MdMessage`'s.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -128,7 +128,7 @@ pub mod market_by_price_diff {
         Add = 0,
         /// This operation is used when a price level is removed from the book.
         Remove = 1,
-        /// This operation is used when a new price level is added or 
+        /// This operation is used when a new price level is added or
         /// an existing price level is modified.
         Replace = 2,
     }
@@ -186,7 +186,7 @@ pub mod market_by_order {
         pub price: u64,
         #[prost(uint64, tag="2")]
         pub quantity: u64,
-        /// [Exchange order ID](/docs/api_reference/trade#exchange-order-id)
+        /// [Exchange order ID](./websocket-trade-api.md#exchange-order-id)
         #[prost(uint64, tag="3")]
         pub exchange_order_id: u64,
         #[prost(enumeration="super::Side", tag="4")]
@@ -241,14 +241,14 @@ pub mod market_by_order_diff {
         pub price: u64,
         #[prost(uint64, tag="2")]
         pub quantity: u64,
-        /// [Exchange order ID](/docs/api_reference/trade#exchange-order-id)
+        /// [Exchange order ID](./websocket-trade-api.md#exchange-order-id)
         #[prost(uint64, tag="3")]
         pub exchange_order_id: u64,
         #[prost(enumeration="super::Side", tag="4")]
         pub side: i32,
         #[prost(enumeration="DiffOp", tag="5")]
         pub op: i32,
-        /// See \[`MarketByOrder.Order`\](#market-by-order-order)
+        /// See \[`MarketByOrder.Order`\](#marketbyorder.order)
         #[prost(uint64, tag="6")]
         pub priority: u64,
     }
@@ -318,18 +318,18 @@ pub mod trades {
         /// The side of the aggressing order.
         #[prost(enumeration="super::Side", tag="3")]
         pub aggressing_side: i32,
-        /// The [Exchange order ID](/docs/api_reference/trade#exchange-order-id) of
+        /// The [Exchange order ID](./websocket-trade-api.md#exchange-order-id) of
         /// the resting order.
         #[prost(uint64, tag="4")]
         pub resting_exchange_order_id: u64,
         #[prost(uint64, tag="5")]
         pub fill_quantity: u64,
-        /// The [transact time](/docs/api_reference/trade#transact-time) assigned by
+        /// The [transact time](./websocket-trade-api.md#transact-time) assigned by
         /// the matching engine for this trade. All trades that occur from the same
         /// event will be assigned the same transact time.
         #[prost(uint64, tag="6")]
         pub transact_time: u64,
-        /// The [Exchange order ID](/docs/api_reference/trade#exchange-order-id) of
+        /// The [Exchange order ID](./websocket-trade-api.md#exchange-order-id) of
         /// the aggressing order.
         #[prost(uint64, tag="7")]
         pub aggressing_exchange_order_id: u64,
@@ -459,7 +459,7 @@ pub mod agg_message {
 pub struct TopOfBook {
     #[prost(uint64, tag="1")]
     pub market_id: u64,
-    /// The [transact time](/docs/api_reference/trade#transact-time) of the latest
+    /// The [transact time](./websocket-trade-api.md#transact-time) of the latest
     /// book update on this market.
     #[prost(uint64, tag="2")]
     pub transact_time: u64,

--- a/schema/market_data.proto
+++ b/schema/market_data.proto
@@ -8,13 +8,13 @@
 // price level through the Market by Price (MBP) and order-by-order through the
 // Market by Order (MBO). In addition, clients can subscribe to the trade stream
 // and price candlesticks. Clients should submit a [`Config`](#config) and then
-// process [`MdMessage`'s](#md-message).
+// process [`MdMessage`](#mdmessage)'s.
 //
 // ### Aggregate Book Tops Data
 //
 // The market data service exposes a websocket endpoint for aggregated
 // tops-of-book for all markets at `/tops`. Client should process
-// [`AggMessage`](#agg-message).
+// [`AggMessage`](#aggmessage).
 //
 // ### Heartbeats
 //
@@ -53,7 +53,7 @@ enum KlineInterval {
 }
 
 // Every exchange message from `/book/:market_id` will be wrapped as an
-// [`MdMessages`](#md-messages) which contains multiple `MdMessage`'s.
+// [`MdMessages`](#mdmessages) which contains multiple `MdMessage`'s.
 message MdMessage {
   oneof inner {
     // Server heartbeat reply
@@ -112,7 +112,7 @@ message MarketByPriceDiff {
     ADD = 0;
     // This operation is used when a price level is removed from the book.
     REMOVE = 1;
-    // This operation is used when a new price level is added or 
+    // This operation is used when a new price level is added or
     // an existing price level is modified.
     REPLACE = 2;
   }
@@ -140,7 +140,7 @@ message MarketByOrder {
   message Order {
     uint64 price = 1;
     uint64 quantity = 2;
-    // [Exchange order ID](/docs/api_reference/trade#exchange-order-id)
+    // [Exchange order ID](./websocket-trade-api.md#exchange-order-id)
     uint64 exchange_order_id = 3;
     Side side = 4;
     // Order priority for execution. Valid within a price level and side. That
@@ -183,11 +183,11 @@ message MarketByOrderDiff {
   message Diff {
     uint64 price = 1;
     uint64 quantity = 2;
-    // [Exchange order ID](/docs/api_reference/trade#exchange-order-id)
+    // [Exchange order ID](./websocket-trade-api.md#exchange-order-id)
     uint64 exchange_order_id = 3;
     Side side = 4;
     DiffOp op = 5;
-    // See [`MarketByOrder.Order`](#market-by-order-order)
+    // See [`MarketByOrder.Order`](#marketbyorder.order)
     uint64 priority = 6;
   }
 }
@@ -206,15 +206,15 @@ message Trades {
     uint64 price = 2;
     // The side of the aggressing order.
     Side aggressing_side = 3;
-    // The [Exchange order ID](/docs/api_reference/trade#exchange-order-id) of
+    // The [Exchange order ID](./websocket-trade-api.md#exchange-order-id) of
     // the resting order.
     uint64 resting_exchange_order_id = 4;
     uint64 fill_quantity = 5;
-    // The [transact time](/docs/api_reference/trade#transact-time) assigned by
+    // The [transact time](./websocket-trade-api.md#transact-time) assigned by
     // the matching engine for this trade. All trades that occur from the same
     // event will be assigned the same transact time.
     uint64 transact_time = 6;
-    // The [Exchange order ID](/docs/api_reference/trade#exchange-order-id) of
+    // The [Exchange order ID](./websocket-trade-api.md#exchange-order-id) of
     // the aggressing order.
     uint64 aggressing_exchange_order_id = 7;
   }
@@ -286,7 +286,7 @@ message AggMessage {
 // Top of book
 message TopOfBook {
   uint64 market_id = 1;
-  // The [transact time](/docs/api_reference/trade#transact-time) of the latest
+  // The [transact time](./websocket-trade-api.md#transact-time) of the latest
   // book update on this market.
   uint64 transact_time = 2;
   // The best bid price.

--- a/schema/trade.proto
+++ b/schema/trade.proto
@@ -7,8 +7,8 @@
 // Once connected, clients should submit a [`Credentials`](#credentials)
 // message, listen for [`Bootstrap`](#bootstrap) messages for resting orders
 // and positions, and then can begin submitting
-// [`OrderRequest`](#order-request) and processing
-// [`OrderResponse`](#order-response).
+// [`OrderRequest`](#orderrequest) and processing
+// [`OrderResponse`](#orderresponse).
 //
 // ### Heartbeats
 //
@@ -73,7 +73,7 @@
 //
 // If you need exact granularity at time of trade, you can replicate the fee calculation performed by the exchange.
 // To avoid rounding errors, this entire process is performed in integer math using the exponent as a devisor.
-// In the example above, the full fee amount in indivisible [RawUnits](#raw-units) would be calculated as:
+// In the example above, the full fee amount in indivisible [RawUnits](#rawunits) would be calculated as:
 // ```text
 // 5 * 100_000_000 * 11 / 10_000 = 550_000 RawUnits
 //


### PR DESCRIPTION
Different systems have different rules to generator anchor links. For header `MarketByPrice.Level`, GitBook generates `marketbyprice.level`, `protoc-gen-doc` generates `MarketByPrice-Level`, our `protoc-gen-doc` fork generates `market-by-price-level`. In this PR (and the dependency PR listed below), we align our rules with GitBook's, because GitBook wouldn't let us change their rules through config. With this PR, we can simply copy the generated `md` files to GitBook without editing.

dependency: https://github.com/cubexch/protoc-gen-doc/pull/1

- internal anchor hyperlinks (linking to a header in the same page) are working
- cross-page anchor hyperlinks (linking from `market-data-api` to a header in `trade-api`) are working
- hyperlinks to scalar types shouldn't exist but `protoc-gen-doc` is no longer under maintenance (https://github.com/pseudomuto/protoc-gen-doc/issues/469). Should we fix it in our fork?